### PR TITLE
Fix 500 errors on content pages (PHP 7.4 AreaList + theme path)

### DIFF
--- a/magento/ansible/deploy.yml
+++ b/magento/ansible/deploy.yml
@@ -143,6 +143,12 @@
         regexp: '^\s*\$errorNo = \$errorNo & error_reporting\(\);'
         line: "        $errorNo = $errorNo & error_reporting() & ~E_DEPRECATED & ~E_USER_DEPRECATED;"
 
+    - name: Patch AreaList to guard null areas (PHP 7.4 null array access notice)
+      ansible.builtin.replace:
+        path: "{{ build_dir }}/public_html/vendor/magento/framework/App/AreaList.php"
+        regexp: "if \\(\\$areaInfo\\['frontName'\\] == \\$frontName\\)"
+        replace: "if (is_array($areaInfo) && (($areaInfo['frontName'] ?? null) == $frontName))"
+
     - name: Regenerate autoloader (no classmap — allows bootstrap without proxies)
       become: yes
       ansible.builtin.shell:

--- a/magento/ansible/deploy.yml
+++ b/magento/ansible/deploy.yml
@@ -17,7 +17,7 @@
     - name: Sync active theme
       synchronize:
         src: "{{ playbook_dir }}/../themes/metatooth/default/"
-        dest: "{{ build_dir }}/public_html/app/design/frontend/Metatooth/default/"
+        dest: "{{ build_dir }}/public_html/app/design/frontend/Metatooth/threetwenty/"
         rsync_opts:
           - "--exclude=.gitignore"
       tags: sync

--- a/magento/themes/metatooth/default/registration.php
+++ b/magento/themes/metatooth/default/registration.php
@@ -6,6 +6,6 @@
 
 \Magento\Framework\Component\ComponentRegistrar::register(
     \Magento\Framework\Component\ComponentRegistrar::THEME,
-    'frontend/Metatooth/default',
+    'frontend/Metatooth/threetwenty',
     __DIR__
 );


### PR DESCRIPTION
## Summary

- Deploy theme to `Metatooth/threetwenty/` path to match the DB-assigned theme (renamed dir was causing 500s on non-cached pages)
- Patch `AreaList::getCodeByFrontName` to guard against null area entries — PHP 7.4 converts the resulting notice to an exception via `ErrorHandler`

## Test plan

- [x] Deployed to shop.metatooth.com and verified all content pages return 200:
  - /about/
  - /faq/
  - /blog/
  - /contact/
  - /material-safety-nightguard/
  - /cleaning-custom-night-guard/

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)