### PR TITLE
fix deprecated implode() warnings on Magento storefront

### DIFF
--- a/magento/ansible/deploy.yml
+++ b/magento/ansible/deploy.yml
@@ -137,6 +137,12 @@
           sed -i 's/return (string) \$type;/return $type->getName();/'
           {{ build_dir }}/public_html/vendor/zendframework/zend-code/src/Reflection/ParameterReflection.php
 
+    - name: Patch UnionExpression implode() argument order for PHP 7.4 (issue #16)
+      ansible.builtin.shell:
+        cmd: >
+          sed -i 's/implode(\$parts, \$this->type)/implode($this->type, $parts)/'
+          {{ build_dir }}/public_html/vendor/magento/framework/DB/Sql/UnionExpression.php
+
     - name: Patch Magento ErrorHandler to ignore E_DEPRECATED (PHP 7.4)
       ansible.builtin.lineinfile:
         path: "{{ build_dir }}/public_html/vendor/magento/framework/App/ErrorHandler.php"


### PR DESCRIPTION
Closes #16

## Summary

- Adds a `sed` patch step in `magento/ansible/deploy.yml` that swaps the `implode()` argument order in `vendor/magento/framework/DB/Sql/UnionExpression.php` from the deprecated `implode($array, $glue)` to `implode($glue, $array)`
- Follows the same pattern as the existing PHP 7.4 compatibility patches in the playbook

## Test plan

- [x] Deployed to `thermos.metatooth.com` and verified no deprecation warnings appear on storefront pages